### PR TITLE
add exemption for html and body selections

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,12 @@ module.exports = {
         "selector-max-empty-lines": 0,
         "selector-max-id": 0,
         "selector-max-specificity": "0,4,0",
-        "selector-max-type": 0,
+        "selector-max-type": [ 0, {
+                "ignoreTypes": [
+                        "/^(html|body)$/"
+                    ]
+            }
+        ],
         "selector-no-qualifying-type": true,
         "selector-pseudo-class-case": "lower",
         "selector-pseudo-class-parentheses-space-inside": "never",

--- a/index.js
+++ b/index.js
@@ -305,11 +305,13 @@ module.exports = {
         "selector-max-empty-lines": 0,
         "selector-max-id": 0,
         "selector-max-specificity": "0,4,0",
-        "selector-max-type": [ 0, {
+        "selector-max-type": [
+            0,
+            {
                 "ignoreTypes": [
-                        "/^(html|body)$/"
-                    ]
-            }
+                    "/^(html|body)$/"
+                ]
+            }            
         ],
         "selector-no-qualifying-type": true,
         "selector-pseudo-class-case": "lower",

--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ module.exports = {
                 "ignoreTypes": [
                     "/^(html|body)$/"
                 ]
-            }            
+            }
         ],
         "selector-no-qualifying-type": true,
         "selector-pseudo-class-case": "lower",


### PR DESCRIPTION
`HTML` and `BODY` are unique elements in a page and are often used to either fix browser bugs or set global things e.g. fonts in which case this seems pretty safe.