### PR TITLE
Bump everything to @latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
         "stylelint-no-unsupported-browser-features"
     ],
     "rules": {
-        "at-rule-blacklist": ["extend"],
+        "at-rule-disallowed-list": ["extend"],
         "at-rule-name-case": "lower",
         "at-rule-name-space-after": "always-single-line",
         "at-rule-semicolon-newline-after": "always",
@@ -222,7 +222,7 @@ module.exports = {
         "declaration-colon-newline-after": "always-multi-line",
         "declaration-colon-space-after": "always-single-line",
         "declaration-colon-space-before": "never",
-        "declaration-property-value-blacklist": {
+        "declaration-property-value-disallowed-list": {
             "/^transition/": [
                 "/all/"
             ],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "homepage": "https://github.com/NewOrbit/stylelint-config#readme",
     "dependencies": {},
     "peerDependencies": {
-        "stylelint": "^13.8.0",
+        "stylelint": "^13.9.0",
         "stylelint-scss": "^3.18.0",
         "stylelint-order": "^4.1.0",
         "stylelint-no-unsupported-browser-features": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "homepage": "https://github.com/NewOrbit/stylelint-config#readme",
     "dependencies": {},
     "peerDependencies": {
-        "stylelint": "8.x",
-        "stylelint-scss": "2.x",
-        "stylelint-order": "0.x",
-        "stylelint-no-unsupported-browser-features": "3.x"
+        "stylelint": "^13.8.0",
+        "stylelint-scss": "^3.18.0",
+        "stylelint-order": "^4.1.0",
+        "stylelint-no-unsupported-browser-features": "^4.1.4"
     }
 }


### PR DESCRIPTION
Bumping everything to version working in my current env.

Only applied renames for deprecated, no other rule changes.

This PR only intends to bump version to remove annoying peer dependency and deprecation warnings, it ignores any new rules worth including.